### PR TITLE
Build using a container for portability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
         run: sam validate
 
       - name: SAM Build
-        run: sam build
+        run: sam build --use-container
 
       - name: SAM Deploy
         run: |


### PR DESCRIPTION
Build using a container as it's much more portable.

The user should not have to worry about runtime dependencies when building.
