### PR TITLE
Fix ImportError: cannot import name 'soft_unicode' from 'markupsafe'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Setup SAM
         uses: aws-actions/setup-sam@v1
+        with:
+          version: 1.37.0
 
       - name: Cache SAM build
         id: cache


### PR DESCRIPTION
It's a good idea to pin sam deployments to avoid breaking existing deployments.

I'd also like to propose we tag this v1 to avoid having to open ~10 or so PRs for small changes.
